### PR TITLE
Move bib -1 to seed data to fix db creation

### DIFF
--- a/Open-ILS/src/sql/Pg/010.schema.biblio.sql
+++ b/Open-ILS/src/sql/Pg/010.schema.biblio.sql
@@ -59,7 +59,6 @@ CREATE TABLE biblio.record_entry (
     merged_to   BIGINT REFERENCES biblio.record_entry(id),
     remote_id   TEXT
 );
-INSERT INTO biblio.record_entry VALUES (-1,1,1,1,-1,NOW(),NOW(),FALSE,FALSE,'','AUTOGEN','-1','<record xmlns="http://www.loc.gov/MARC21/slim"/>','FOO');
 
 CREATE INDEX biblio_record_entry_creator_idx ON biblio.record_entry ( creator );
 CREATE INDEX biblio_record_entry_create_date_idx ON biblio.record_entry ( create_date );

--- a/Open-ILS/src/sql/Pg/950.data.seed-values.sql
+++ b/Open-ILS/src/sql/Pg/950.data.seed-values.sql
@@ -2882,6 +2882,11 @@ INSERT INTO permission.usr_perm_map (usr,perm,depth) VALUES (1,-1,0);
 -- Set a work_ou for the Administrator user
 INSERT INTO permission.usr_work_ou_map (usr, work_ou) VALUES (1, 1);
 
+--010.schema.biblio.sql:
+ALTER TABLE biblio.record_entry DISABLE TRIGGER bre_load_item_tgr;
+INSERT INTO biblio.record_entry VALUES (-1,1,1,1,-1,NOW(),NOW(),FALSE,FALSE,'','AUTOGEN','-1','<record xmlns="http://www.loc.gov/MARC21/slim"/>','FOO');
+ALTER TABLE biblio.record_entry ENABLE TRIGGER bre_load_item_tgr;
+
 --040.schema.asset.sql:
 INSERT INTO asset.copy_location (id, name,owning_lib) VALUES (1, oils_i18n_gettext(1, 'Stacks', 'acpl', 'name'),1);
 SELECT SETVAL('asset.copy_location_id_seq'::TEXT, 100);


### PR DESCRIPTION
When in 010.schema.biblio.sql we now get an fkey violation on
actor.usr, and if bre_load_item_tgr isn't disabled when inserted
we get an fkey violation on action_trigger.event_definition.

Signed-off-by: Jason Boyer <jboyer@equinoxOLI.org>
Signed-off-by: Galen Charlton <gmc@equinoxOLI.org>